### PR TITLE
Allow for multiple SO names on Invoice

### DIFF
--- a/UK_Reports/models/account_invoice.py
+++ b/UK_Reports/models/account_invoice.py
@@ -23,6 +23,7 @@
 from odoo import models, api
 from ..helpers import integer_or_float
 
+
 class AccountInvoice(models.Model):
 	_inherit = "account.invoice"
 
@@ -42,7 +43,7 @@ class AccountInvoice(models.Model):
 		return self.get_sale_order().payment_term_id.name or '(Not provided)'
 
 	def sale_number(self):
-		return self.get_sale_order().name or '(Not provided)'
+		return ", ".join(so.name for so in self.get_sale_order()) or '(Not provided)'
 
 	def get_sale_order(self):
 		return self.env['sale.order'].search([]).filtered(


### PR DESCRIPTION
[O2200][I2] Singleton error occurs when trying to print an invoice that is based off multiple sales orders.

Signed-off-by: James Curtis <james.curtis@opusvl.com>