### PR TITLE
[FIX] Sale, Purchase & Invoice reports don't use line name

### DIFF
--- a/UK_Reports/models/account_move.py
+++ b/UK_Reports/models/account_move.py
@@ -45,13 +45,9 @@ class AccountMoveLine(models.Model):
 	_inherit = "account.move.line"
 
 	def uk_report_description_format(self):
-		if self.product_id.default_code:
-			return "[{}] {}".format(
-				self.product_id.default_code,
-				self.product_id.name
-			)
-		else:
-			return self.product_id.name
+		return self.name or "[{}] {}".format(
+			self.product_id.default_code, self.product_id.name
+		) if self.product_id.default_code else self.product_id.name
 
 	def qty_format(self):
 		return integer_or_float(self.quantity)

--- a/UK_Reports/models/purchase_order.py
+++ b/UK_Reports/models/purchase_order.py
@@ -28,7 +28,7 @@ class PurchaseOrderLine(models.Model):
 	_inherit = "purchase.order.line"
 
 	def uk_report_description_format(self):
-		return "[{}] {}".format(
+		return self.name or "[{}] {}".format(
 			self.product_id._vendor_specific_code(self.order_id.partner_id)
 			or self.product_id.default_code,
 			self.product_id.name

--- a/UK_Reports/models/sale_order.py
+++ b/UK_Reports/models/sale_order.py
@@ -37,13 +37,9 @@ class SaleOrderLine(models.Model):
 	_inherit = "sale.order.line"
 
 	def uk_report_description_format(self):
-		if self.product_id.default_code:
-			return "[{}] {}".format(
-				self.product_id.default_code,
-				self.product_id.name
-			)
-		else:
-			return self.product_id.name
+		return self.name or "[{}] {}".format(
+			self.product_id.default_code, self.product_id.name
+		) if self.product_id.default_code else self.product_id.name
 
 	def qty_format(self):
 		return integer_or_float(self.product_uom_qty)


### PR DESCRIPTION
When printing a report for a Sale, Purchase or Invoice, the table of lines should use the line name before falling back to the product.

Fixes #O2644