### PR TITLE
O2671 wave 1, Remittance advice & Invoice changes

### DIFF
--- a/UK_Reports/models/account_move.py
+++ b/UK_Reports/models/account_move.py
@@ -28,7 +28,7 @@ class AccountMove(models.Model):
 	_inherit = "account.move"
 
 	def your_reference_format(self):
-		return self.name or '(Not provided)'
+		return self.ref or '(Not provided)'
 
 	def sale_payment_term(self):
 		return self.get_sale_order().payment_term_id.name or '(Not provided)'

--- a/UK_Reports/reports/generic_templates.xml
+++ b/UK_Reports/reports/generic_templates.xml
@@ -127,10 +127,10 @@
 					<tr t-foreach="o.invoice_line_ids" t-as="line">
 						<td t-esc="line.uk_report_description_format() or ' '"/>
 						<td t-esc="line.qty_format()" class="text-right"/>
-						<td t-esc="line.price_unit" class="text-right" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-						<td t-esc="line.price_subtotal" class="text-right" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-						<td t-esc="line.total_tax_format()" class="text-right"  t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-						<td t-esc="line.total_gross_format()" class="text-right" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+						<td t-esc="'{0:,.2f}'.format(line.price_unit)" class="text-right"/>
+						<td t-esc="'{0:,.2f}'.format(line.price_subtotal)" class="text-right"/>
+						<td t-esc="'{0:,.2f}'.format(line.total_tax_format())" class="text-right"/>
+						<td t-esc="'{0:,.2f}'.format(line.total_gross_format())" class="text-right"/>
 					</tr>
 				</tbody>
 			</table>

--- a/UK_Reports/reports/generic_templates.xml
+++ b/UK_Reports/reports/generic_templates.xml
@@ -83,7 +83,7 @@
 			<table class="payment-invoice-lines">
 				<tr id="row-border-top-1" class="row-border-top row-border-bottom">
 					<td class="text-left bold">Total Paid</td>
-					<td class="text-right"><span t-esc="o.get_amount_total()" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/></td>
+					<td class="text-right"><span t-esc="o.get_amount_total()" t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/></td>
 				</tr>
 			</table>
 		</template>

--- a/UK_Reports/reports/remittance_advice_report.xml
+++ b/UK_Reports/reports/remittance_advice_report.xml
@@ -35,7 +35,7 @@
 						<tbody>
 							<tr t-foreach="o.reconciled_invoice_ids" t-as="invoice">
 								<td class="text-left"><span t-field="invoice.invoice_date" t-options='{"format": "dd/MM/yy"}'/></td>
-								<td t-esc="invoice.name" class="text-left"/>
+								<td t-esc="invoice.ref or invoice.name" class="text-left"/>
 								<td class="text-right"><span t-esc="'{0:,.2f}'.format(invoice.amount_total_signed)"/></td>
 							</tr>
 						</tbody>


### PR DESCRIPTION
1) On the 'Remittance Advice (UK format)' pdf, the 'Invoice/Credit #' column of the invoice lines should show: If it has a 'Reference' (i.e. 'ref' field) then show it, if not then show the system generated invoice reference number (i.e. 'name' field)

2) The email that gets generated from the payment screen is currently showing an unformatted  'Remittance Advice (UK format)' pdf. Please make it to show it in the correct format.

3) On the 'Invoice (UK format)' (i.e. customer invoice), 'Your Reference' should show the value from the 'Reference' (i.e. 'ref' field). If it does not have a Reference, then show it as a blank space.

4) On Customer Invoice, Remove '£' from lines but have it against subtotal, vat, and total

5) In the remittance, on the total, we need ',' and '£'