### PR TITLE
Tolerate null date_maturity on account.move.line

### DIFF
--- a/UK_Reports/models/account_move_line.py
+++ b/UK_Reports/models/account_move_line.py
@@ -25,18 +25,18 @@ from datetime import date, datetime
 
 
 class AccountMoveLine(models.Model):
-	_inherit = "account.move.line"
+    _inherit = "account.move.line"
 
-	statement_account_overdue = fields.Float(compute="_compute_statement_account_values")
-	statement_account_value = fields.Float(compute="_compute_statement_account_values")
+    statement_account_overdue = fields.Float(compute="_compute_statement_account_values")
+    statement_account_value = fields.Float(compute="_compute_statement_account_values")
 
-	@api.depends('date_maturity', 'debit', 'credit')
-	def _compute_statement_account_values(self):
-		todays_date = date.today()
-		for record in self:
-			record.statement_account_value = (record.debit - record.credit)
-			date_maturity_obj = datetime.strptime(record.date_maturity, "%Y-%m-%d")
-			if todays_date > date_maturity_obj.date():
-				record.statement_account_overdue = record.statement_account_value
-			else:
-				record.statement_account_overdue = 0
+    @api.depends('date_maturity', 'debit', 'credit')
+    def _compute_statement_account_values(self):
+        todays_date = date.today()
+        for record in self:
+            record.statement_account_value = (record.debit - record.credit)
+            date_maturity_obj = datetime.strptime(record.date_maturity, "%Y-%m-%d")
+            if todays_date > date_maturity_obj.date():
+                record.statement_account_overdue = record.statement_account_value
+            else:
+                record.statement_account_overdue = 0

--- a/UK_Reports/models/account_move_line.py
+++ b/UK_Reports/models/account_move_line.py
@@ -32,11 +32,13 @@ class AccountMoveLine(models.Model):
 
     @api.depends('date_maturity', 'debit', 'credit')
     def _compute_statement_account_values(self):
+        def is_overdue(moveline, on_this_date):
+            date_maturity_obj = datetime.strptime(moveline.date_maturity, "%Y-%m-%d")
+            return on_this_date > date_maturity_obj.date()
         todays_date = date.today()
         for record in self:
             record.statement_account_value = (record.debit - record.credit)
-            date_maturity_obj = datetime.strptime(record.date_maturity, "%Y-%m-%d")
-            if todays_date > date_maturity_obj.date():
+            if is_overdue(moveline=record, on_this_date=todays_date):
                 record.statement_account_overdue = record.statement_account_value
             else:
                 record.statement_account_overdue = 0

--- a/UK_Reports/models/account_move_line.py
+++ b/UK_Reports/models/account_move_line.py
@@ -36,7 +36,7 @@ class AccountMoveLine(models.Model):
             if moveline.date_maturity:
                 return on_this_date > moveline.date_maturity
             else:
-                # No commercial agreement was in place
+                # No commercial agreement is in place
                 return False
         todays_date = date.today()
         for record in self:

--- a/UK_Reports/models/account_move_line.py
+++ b/UK_Reports/models/account_move_line.py
@@ -21,7 +21,7 @@
 ##############################################################################
 
 from odoo import models, api, fields
-from datetime import date, datetime
+from datetime import date
 
 
 class AccountMoveLine(models.Model):
@@ -34,8 +34,7 @@ class AccountMoveLine(models.Model):
     def _compute_statement_account_values(self):
         def is_overdue(moveline, on_this_date):
             if moveline.date_maturity:
-                date_maturity_obj = datetime.strptime(moveline.date_maturity, "%Y-%m-%d")
-                return on_this_date > date_maturity_obj.date()
+                return on_this_date > moveline.date_maturity
             else:
                 # No commercial agreement was in place
                 return False

--- a/UK_Reports/models/account_move_line.py
+++ b/UK_Reports/models/account_move_line.py
@@ -33,8 +33,12 @@ class AccountMoveLine(models.Model):
     @api.depends('date_maturity', 'debit', 'credit')
     def _compute_statement_account_values(self):
         def is_overdue(moveline, on_this_date):
-            date_maturity_obj = datetime.strptime(moveline.date_maturity, "%Y-%m-%d")
-            return on_this_date > date_maturity_obj.date()
+            if moveline.date_maturity:
+                date_maturity_obj = datetime.strptime(moveline.date_maturity, "%Y-%m-%d")
+                return on_this_date > date_maturity_obj.date()
+            else:
+                # No commercial agreement was in place
+                return False
         todays_date = date.today()
         for record in self:
             record.statement_account_value = (record.debit - record.credit)


### PR DESCRIPTION
I also uncovered a whitespace issue in the source code (tabs instead of spaces) and a further bug related to strings vs date objects in the not null case.

I recommend looking at the commits individually to understand what fixed which issue.

This is not to be merged until it's been tested on the reporting customer's system.  Internal ref: T16990